### PR TITLE
Fixes content leaking from under the header

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -9,6 +9,7 @@
   left: 0;
   right: 0;
   z-index: 2;
+  background-color: white: 
 }
 .headroom--unfixed {
   position: relative;


### PR DESCRIPTION
The header wrapper element is not wide enough to cover the whole content width thus content is leaking on the side when scrolling to the top:

![](https://puu.sh/tkReV/8ec1a9eb72.png)
