### PR TITLE
Fixes header on 1800+ width screens

### DIFF
--- a/utils/components.js
+++ b/utils/components.js
@@ -7,6 +7,7 @@ export const Header = styled.header`
   display: flex;
   padding: 24px 32px;
   max-width: 1440px;
+  margin: 0 auto;
   justify-content: space-between;
   align-items: center;
   background-color: white;


### PR DESCRIPTION
This fixex and centers the menu on 1800+ screens.

![](https://camo.githubusercontent.com/b9222ac1f0d4ae7a9cc6f1db66860c4318c74319/68747470733a2f2f7075752e73682f746b5265562f386563316139656237322e706e67)