### PR TITLE
Shorten some very long lines, fix bug with transcripts menu behavior

### DIFF
--- a/pages/_template.jsx
+++ b/pages/_template.jsx
@@ -132,7 +132,25 @@ export default class Template extends React.Component {
         <Footer>
           <div>
             <Copyright>© 2016 Reactiflux</Copyright>
-            <Credits>Designed in <StyledLink href="https://www.sketchapp.com/" title="Sketc">Sketch</StyledLink>. Coded in <StyledLink href="https://atom.io/" title="Atom">Atom</StyledLink>. Built using <StyledLink href="https://github.com/gatsbyjs/gatsby" title="Gatsby">Gatsby.js</StyledLink>. Hosted on <StyledLink href="https://www.netlify.com/" title="Netlify">Netlify</StyledLink>.</Credits>
+            <Credits>
+              {'Designed in '}
+              <StyledLink href="https://www.sketchapp.com/" title="Sketch">
+                Sketch
+              </StyledLink>
+              {'. Coded in '}
+              <StyledLink href="https://atom.io/" title="Atom">
+                Atom
+              </StyledLink>
+              {'. Built using '}
+              <StyledLink href="https://github.com/gatsbyjs/gatsby" title="Gatsby">
+                Gatsby.js
+              </StyledLink>
+              {'. Hosted on '}
+              <StyledLink href="https://www.netlify.com/" title="Netlify">
+                Netlify
+              </StyledLink>
+              .
+            </Credits>
           </div>
           <SocialLinks>
             <IconLink

--- a/pages/_template.jsx
+++ b/pages/_template.jsx
@@ -7,7 +7,19 @@ import '../css/markdown-styles'
 import '../css/styles'
 
 import { rhythm } from '../utils/typography'
-import { Header, Navigation, Toggle, Logo, StyledLink, NavigationLink, Footer, Copyright, Credits, IconLink, SocialLinks } from '../utils/components'
+import {
+  Header,
+  Navigation,
+  Toggle,
+  Logo,
+  StyledLink,
+  NavigationLink,
+  Footer,
+  Copyright,
+  Credits,
+  IconLink,
+  SocialLinks
+} from '../utils/components'
 import { Discord, Twitter, Github } from '../assets/logos.js'
 
 export default class Template extends React.Component {
@@ -33,7 +45,7 @@ export default class Template extends React.Component {
   handleResize = () => {
     if (this.onMobile()) {
       const { transcript, toc } = this.state
-      if(!transcript || !toc) {
+      if (!transcript || !toc) {
         this.setState({
           transcript: true,
           toc: true
@@ -63,7 +75,14 @@ export default class Template extends React.Component {
     const { menu, transcript, toc } = this.state
     const closeMenu = this.close('menu')
 
-    const children = React.Children.map(this.props.children, (child) => React.cloneElement(child, { transcript, toc, toggle: this.toggle, close: this.close }))
+    const children = React.Children.map(
+      this.props.children,
+      (child) =>
+        React.cloneElement(
+          child,
+          { transcript, toc, toggle: this.toggle, close: this.close }
+        )
+    )
 
     return (
       <div style={{position: menu ? 'fixed' : 'inherit'}}>

--- a/pages/_template.jsx
+++ b/pages/_template.jsx
@@ -23,15 +23,15 @@ export default class Template extends React.Component {
   }
 
   componentDidMount() {
-      window.addEventListener("resize", this.checkSize);
+      window.addEventListener("resize", this.handleResize);
   }
 
   componentWillUnmount() {
-      window.removeEventListener("resize", this.checkSize);
+      window.removeEventListener("resize", this.handleResize);
   }
 
-  checkSize = () => {
-    if(window.innerWidth > 768) {
+  handleResize = () => {
+    if (this.onMobile()) {
       const { transcript, toc } = this.state
       if(!transcript || !toc) {
         this.setState({
@@ -42,6 +42,8 @@ export default class Template extends React.Component {
     }
   }
 
+  onMobile = () => window.innerWidth <= 768
+
 
   toggle = (item) => () => {
     this.setState((prevState) => ({
@@ -50,9 +52,11 @@ export default class Template extends React.Component {
   }
 
   close = (item) => () => {
-    this.setState({
-      [item]: false
-    })
+    if (this.onMobile()) {
+      this.setState({
+        [item]: false
+      })
+    }
   }
 
   render () {

--- a/pages/index.js
+++ b/pages/index.js
@@ -24,7 +24,7 @@ export default class Index extends React.Component {
           We&rsquo;re a chat community of 20,000+ React&nbsp;JS&nbsp;<IconLink to="https://github.com/facebook/react" target="_blank" title="React JS" src={ReactLogo} alt="React Logo"/>, React&nbsp;Native&nbsp;<IconLink to="https://github.com/facebook/react-native" target="_blank" title="React Native" src={ReactNative} alt="React Native Logo"/>, Redux&nbsp;<IconLink to="https://github.com/reactjs/redux" target="_blank" title="Redux" src={Redux} alt="Redux Logo"/>,
           Relay&nbsp;<IconLink to="https://github.com/facebook/relay" target="_blank" title="Relay" src={Relay} alt="Relay Logo"/> and
           GraphQL&nbsp;<IconLink to="https://github.com/facebook/graphql" target="_blank" title="GraphQL" src={GraphQL} alt="GraphQL Logo"/> developers.
-          We hold Q&A&rsquo;s with Facebook Engineers&nbsp;<IconLink to="https://github.com/facebook" target="_blank" title="Facebook Organization" src={Facebook} alt="Facebook Logo"/> and
+          We hold Q&amp;A&rsquo;s with Facebook Engineers&nbsp;<IconLink to="https://github.com/facebook" target="_blank" title="Facebook Organization" src={Facebook} alt="Facebook Logo"/> and
           other developers&nbsp;<IconLink to="https://github.com/reactiflux" target="_blank" title="Reactiflux Developers" src={Console} alt="Developers Logo"/> in
           the community&nbsp;<IconLink to="https://discordapp.com/invite/0ZcbPKXt5bYZVCkR" target="_blank" title="Reactiflux Discord" src={Community} alt="Community Logo"/>. Come chat about tech
           related to React & JavaScript or ask for help!

--- a/pages/transcripts/index.js
+++ b/pages/transcripts/index.js
@@ -1,21 +1,35 @@
 import React from 'react'
 import Helmet from "react-helmet"
-import { Container, SmallTitle, SideBar, MarkdownContainer, StyledLink } from '../../utils/components'
+import {
+  Container,
+  SmallTitle,
+  SideBar,
+  MarkdownContainer,
+  StyledLink
+} from '../../utils/components'
 
 
 export default class Transcripts extends React.Component {
 
   render () {
-    const articles = this.props.route.pages.filter((route) => {
-        if(route.path !== '/transcripts/' && route.path.indexOf('/transcripts/') != -1)
-          return route;
-    });
+    const articles = this.props.route.pages.filter((route) =>
+      route.path !== '/transcripts/' &&
+      route.path.indexOf('/transcripts/') != -1
+    );
 
     const { transcript, close, toggle } = this.props
 
-    const items = articles.map((article) => {
-      return <li key={article.data.title}><StyledLink onClick={close('transcript')} to={article.path} title={article.data.title}>{article.data.title}</StyledLink></li>
-    });
+    const items = articles.map((article) =>
+      <li key={ article.data.title }>
+        <StyledLink
+          onClick={ close('transcript') }
+          to={ article.path }
+          title={ article.data.title }
+        >
+          {article.data.title}
+        </StyledLink>
+      </li>
+    );
 
     articles.sort((a, b) => {
       return new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
@@ -29,8 +43,16 @@ export default class Transcripts extends React.Component {
           title={'Reactiflux transcripts'}
         />
         <SmallTitle>{newestArticle.title}</SmallTitle>
-        <SideBar children={items} active={transcript} toggle={toggle('transcript')} />
-        <MarkdownContainer transcript className="markdown"  dangerouslySetInnerHTML={{ __html: newestArticle.body }}/>
+        <SideBar
+          children={items}
+          active={transcript}
+          toggle={toggle('transcript')}
+        />
+        <MarkdownContainer
+          transcript={true}
+          className="markdown"
+          dangerouslySetInnerHTML={{ __html: newestArticle.body }}
+        />
       </Container>
     )
   }

--- a/wrappers/md.js
+++ b/wrappers/md.js
@@ -12,7 +12,7 @@ export default class Markdown extends React.Component {
     const { toc, transcript, close, toggle } = this.props
 
     const articles = this.props.route.pages.filter((route) => {
-        if(route.path !== '/transcripts/' && route.path.indexOf('/transcripts/') != -1)
+        if (route.path !== '/transcripts/' && route.path.indexOf('/transcripts/') != -1)
           return route;
     });
 


### PR DESCRIPTION
Fix transcript menu vanishing when you click a link on desktop.

Current behaviors:
* The "transcripts" menu remains open on desktop, collapses after every click on mobile.
* The "learning" menu remains open after every click on both mobile and desktop.