### PR TITLE
`break-word` for <strong>

### DIFF
--- a/css/markdown-styles.scss
+++ b/css/markdown-styles.scss
@@ -42,7 +42,7 @@
   }
   a, code, strong {
     white-space: pre-wrap;
-    word-break: break-all;
+    word-break: break-word;
     word-wrap: break-word;
   }
 }


### PR DESCRIPTION
You can see this bug in this transcript: https://www.reactiflux.com/transcripts/dan-abramov/

The `<strong>` questions have fragmented word-breaks. 

I did *not* review this change against the whole site, so someone with a dev setup may want to review.