### PR TITLE
Fixed *Eric Elliott's Essential Javascript Links* 404 link

### DIFF
--- a/pages/learning.md
+++ b/pages/learning.md
@@ -35,7 +35,7 @@ A selected list of tutorials, articles, and resources on Javascript, React, Redu
     [Mozilla Developer Network: A Re-Introduction to Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript)  
     Mozilla maintains a fantastic set of developer resources for Web technologies, including a comprehensive reference to the Javascript language and a number of associated tutorials. Their "reintroduction to Javascript" article is a great overview of what the language looks like.
   - [Eric Elliott's Javascript Resource Lists](https://medium.com/javascript-scene/10-priceless-resources-for-javascript-learners-bbf2f7d7f84e)  
-    [Eric Elliott's Essential Javascript Links](https://github.com/ericelliott/essential-javascript-links)  
+    [Eric Elliott's Essential Javascript Links](https://gist.github.com/ericelliott/d576f72441fc1b27dace/0cee592f8f8b7eae39c4b3851ae92b00463b67b9)  
     Eric Elliott is a strong proponent of Javascript, has written numerous articles about learning and understanding Javascript, and assembled some very useful lists of numerous Javascript resources. (Strong opinions, but has useful info.)
   - [Wes Bos's Javascript Resource List](http://wesbos.com/learn-javascript)  
     Speaker and teacher Wes Bos gives links to a number of resources for learning Javascript


### PR DESCRIPTION
Hello!

*Eric Elliott's Essential Javascript Links* link results in a 404 now. Not sure what happened but he has deleted that repository. 

Fortunately, he still has a gist up and running so I have replaced the current link with that gist link.