### PR TITLE
add sidebar toggle button with smooth scroll

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -36,7 +36,7 @@ export function Layout({ as, children, description, title, sidebar, ...props }) 
         <MainStyles />
         <MarkdownStyles />
         <Menu />
-        <Main as={as} {...props} isOpen={isOpen}>
+        <Main as={as} {...props} isOpen={isOpen} sidebar={sidebar}>
           <SEO title={title} description={description} />
           {typeof children === 'function' ? children(toggleIsOpen) : children}
           {sidebar ? (

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -5,7 +5,7 @@ import { useIsMobile } from '@hooks';
 import { getTheme } from '@utils/theme';
 
 import { Footer } from './Footer';
-import { Main, Wrapper } from './LayoutStyles';
+import { Main, SidebarToggleButton, Wrapper } from './LayoutStyles';
 import { MainStyles } from './MainStyles';
 import { MarkdownStyles } from './MarkdownStyles';
 import { Menu } from './Menu';
@@ -16,8 +16,19 @@ import 'typeface-poppins';
 import 'typeface-work-sans';
 import 'typeface-space-mono';
 
-export function Layout({ as, children, title, description, ...props }) {
+export function Layout({ as, children, description, title, sidebar, ...props }) {
   const isMobile = useIsMobile();
+  const [isOpen, setIsOpen] = React.useState(false);
+  const toggleIsOpen = () => setIsOpen(prev => !prev)
+  React.useEffect(() => {
+    if (isOpen) {
+      window.scrollTo({
+        top: 0,
+        left: 0,
+        behavior: 'smooth'
+      });
+    }
+  }, [isOpen])
 
   return (
     <ThemeProvider theme={getTheme({ isMobile })}>
@@ -25,10 +36,16 @@ export function Layout({ as, children, title, description, ...props }) {
         <MainStyles />
         <MarkdownStyles />
         <Menu />
-        <Main as={as} {...props}>
+        <Main as={as} {...props} isOpen={isOpen}>
           <SEO title={title} description={description} />
-          {children}
+          {typeof children === 'function' ? children(toggleIsOpen) : children}
+          {sidebar ? (
+            <SidebarToggleButton isOpen={isOpen} onClick={toggleIsOpen} fixed />
+          ) : null}
         </Main>
+        {sidebar ? (
+          <SidebarToggleButton isOpen={isOpen} onClick={toggleIsOpen} />
+        ) : null}
         <Footer />
       </Wrapper>
     </ThemeProvider>

--- a/src/components/Layout/LayoutStyles.js
+++ b/src/components/Layout/LayoutStyles.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled, { css } from 'styled-components';
 
 import { pink } from '@utils/theme';
@@ -64,6 +65,33 @@ const homeLayout = css`
 `;
 
 const standardLayout = css`
+  @media (max-width: 819px) {
+    display: grid;
+    grid-template-columns: 60% 100%;
+    transform: translateX(${props => props.isOpen ? '0' : 'calc(10px - 60%)'});
+    transition: .4s ease transform;
+
+    > * {
+      grid-column: 2;
+      grid-row: 2;
+    }
+
+    > h1:first-child {
+      grid-column: 2;
+      grid-row: 1;
+    }
+
+    > nav {
+      grid-column: 1;
+      grid-row: 2;
+      padding-right: 1rem;
+    }
+
+    > div {
+      padding-left: 4rem;
+    }
+  }
+
   @media (min-width: 820px) {
     display: grid;
     grid-template-columns: 1fr 2fr;
@@ -96,6 +124,44 @@ export const Main = styled.main`
 
   ${(props) => (props.homepage ? homeLayout : standardLayout)}
 `;
+
+const fixedSidebarButton = css`
+  font-size: 3rem;
+  left: 0;
+  position: fixed;
+  top: 0;
+  transform: rotate(90deg) translateX(-30px);
+  transform-origin: bottom left;
+
+  &:focus {
+    border: 3px solid #dc1d64;
+    margin: -9px -3px;
+  }
+`
+
+export const SidebarButton = styled.button`
+  background: none;
+  border: none;
+  color: #dc1d64;
+  cursor: pointer;
+  display: inline-block;
+  font-family: inherit;
+  font-size: 1.9rem;
+  line-height: 1;
+  outline: none;
+  padding: 0 3px;
+  white-space: nowrap;
+
+  ${props => props.fixed && fixedSidebarButton}
+`
+
+export function SidebarToggleButton(props) {
+  return (
+    <SidebarButton {...props}>
+      {props.isOpen ? 'Hide' : 'Show'} Menu
+    </SidebarButton>
+  )
+}
 
 export const Wrapper = styled.div`
   display: flex;

--- a/src/components/Layout/LayoutStyles.js
+++ b/src/components/Layout/LayoutStyles.js
@@ -84,12 +84,14 @@ const standardLayout = css`
     > nav {
       grid-column: 1;
       grid-row: 2;
-      padding-right: 1rem;
+      ${props => props.sidebar && css`padding-right: 1rem`}
     }
 
-    > div {
-      padding-left: 4rem;
-    }
+    ${props => props.sidebar && css`
+      > div {
+        padding-left: 4rem;
+      }
+    `}
   }
 
   @media (min-width: 820px) {

--- a/src/components/Layout/LayoutStyles.js
+++ b/src/components/Layout/LayoutStyles.js
@@ -136,7 +136,7 @@ const fixedSidebarButton = css`
   transform-origin: bottom left;
 
   &:focus {
-    border: 3px solid #dc1d64;
+    border: 3px solid ${pink};
     margin: -9px -3px;
   }
 `
@@ -144,7 +144,7 @@ const fixedSidebarButton = css`
 export const SidebarButton = styled.button`
   background: none;
   border: none;
-  color: #dc1d64;
+  color: ${pink};
   cursor: pointer;
   display: inline-block;
   font-family: inherit;

--- a/src/components/Layout/MenuStyles.js
+++ b/src/components/Layout/MenuStyles.js
@@ -17,6 +17,7 @@ export const MobileNav = styled.div`
   line-height: 42px;
   position: fixed;
   width: 100%;
+  z-index: 999;
 
   a {
     padding: 0 6px;

--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,50 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import smoothScrollToAnchor from '!raw-loader!./scripts/smoothScrollToAnchor.js'
+
+const smoothScrollScript = (
+  <script
+      dangerouslySetInnerHTML={{
+          __html: smoothScrollToAnchor
+      }}
+  />
+)
+
+export default function HTML(props) {
+  return (
+    <html {...props.htmlAttributes}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        {props.headComponents}
+      </head>
+      <body {...props.bodyAttributes}>
+        {props.preBodyComponents}
+        <noscript key="noscript" id="gatsby-noscript">
+          This app works best with JavaScript enabled.
+        </noscript>
+        <div
+          key={`body`}
+          id="___gatsby"
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
+        {props.postBodyComponents}
+        {smoothScrollScript}
+      </body>
+    </html>
+  )
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+}

--- a/src/pages/transcripts.js
+++ b/src/pages/transcripts.js
@@ -15,7 +15,7 @@ export default function Transcripts({ data }) {
   const newestArticle = articles[0];
 
   return (
-    <Layout title="Transcripts">
+    <Layout title="Transcripts" sidebar>
       <h1>{newestArticle.title}</h1>
       <div>
         <time>Transcript from {newestArticle.date}</time>

--- a/src/scripts/smoothScrollToAnchor.js
+++ b/src/scripts/smoothScrollToAnchor.js
@@ -1,0 +1,11 @@
+;(function () {
+    document.addEventListener('click', function (e) {
+        if (e.target.matches('a[href^="#"]')) {
+            e.preventDefault()
+
+            document.querySelector(e.target.getAttribute('href')).scrollIntoView({
+                behavior: 'smooth'
+            });
+        }
+    })
+})()

--- a/src/templates/CopyPage.js
+++ b/src/templates/CopyPage.js
@@ -8,22 +8,26 @@ export default function Transcript({ data }) {
   const { html, frontmatter, headings } = data.markdownRemark;
 
   return (
-    <Layout title={frontmatter.title}>
-      <h1>{frontmatter.title}</h1>
-      <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />
-      {frontmatter.sidebar ? (
-        <nav>
-          <ol>
-            {headings
-              .filter((heading) => heading.depth < 3)
-              .map(({ value }) => (
-                <li key={value}>
-                  <Link to={getAnchor(value)}>{value}</Link>
-                </li>
-              ))}
-          </ol>
-        </nav>
-      ) : null}
+    <Layout title={frontmatter.title} sidebar={frontmatter.sidebar}>
+      {toggleSidebar => (
+        <>
+          <h1>{frontmatter.title}</h1>
+          <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />
+          {frontmatter.sidebar ? (
+            <nav>
+              <ol>
+                {headings
+                  .filter((heading) => heading.depth < 3)
+                  .map(({ value }) => (
+                    <li key={value}>
+                      <Link to={getAnchor(value)} onClick={toggleSidebar}>{value}</Link>
+                    </li>
+                  ))}
+              </ol>
+            </nav>
+          ) : null}
+        </>
+      )}
     </Layout>
   );
 }

--- a/src/templates/Transcript.js
+++ b/src/templates/Transcript.js
@@ -14,7 +14,7 @@ export default function Transcript({ data }) {
     }));
 
   return (
-    <Layout as="article" title={frontmatter.title}>
+    <Layout as="article" title={frontmatter.title} sidebar>
       <h1>{frontmatter.title}</h1>
       <div>
         <p>


### PR DESCRIPTION
Added toggleable sidebar for smaller screens, with smooth scroll for internal links.

Really not sure about the way it looks but it's at least a small improvement on just shoving the whole thing down to the bottom. One alternative would be to add it to the bottom menu, but we'll already be pushed for space there anyway (even if we do switch to icons with smaller text)... 😕 

<img src="https://user-images.githubusercontent.com/19466326/68998987-7c8bed00-08b1-11ea-8ef0-ce4cd66dcecd.gif" width="398px" />
