### PR TITLE
fix anchor links in transcripts

### DIFF
--- a/src/scripts/smoothScrollToAnchor.js
+++ b/src/scripts/smoothScrollToAnchor.js
@@ -1,11 +1,17 @@
-;(function () {
-    document.addEventListener('click', function (e) {
-        if (e.target.matches('a[href^="#"]')) {
-            e.preventDefault()
+;(function() {
+  document.addEventListener('click', function(e) {
+    if (e.target.matches('a[href^="#"]')) {
+      e.preventDefault();
 
-            document.querySelector(e.target.getAttribute('href')).scrollIntoView({
-                behavior: 'smooth'
-            });
-        }
-    })
-})()
+      const target = e.target.getAttribute('href').replace('#', '');
+
+      const element =
+        document.getElementById(target) ||
+        document.querySelector(`[name="${target}"]`);
+
+      element.scrollIntoView({
+        behavior: 'smooth',
+      });
+    }
+  });
+})();


### PR DESCRIPTION
Current version assumes that the `#target` is an element with an id; we need to also support `[name="#target"]` selector. 🙃 