### PR TITLE
make regex conditional

### DIFF
--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -31,10 +31,13 @@ export const extractTags = (message) => {
 
   let content = message;
   // remove tags from content
-  content = content.replace(
-    new RegExp(matches.map((tag) => `\\${tag}`).join('|'), 'gi'),
-    '',
-  );
+  try {
+    content = content.replace(
+      new RegExp(matches.map((tag) => `\\${tag}`).join('|'), 'gi'),
+      '',
+    );
+  } catch(e) {
+  }
   // remove leading whitespace and newlines
   content = content.replace(/^\s+\n+/gi, '');
 


### PR DESCRIPTION
Jobs page was crashing - looks like it's because of the regex. At the moment, we do this:

- parse the `[TAGS]` from the post content
- render the list of tags at the top of the post
- convert the list of tags into a regex
- strip the tags from the main content of the post

For one of the posts this is creating an invalid regex when it does the conversion. This is the offending post:

![image](https://user-images.githubusercontent.com/19466326/70761701-10809580-1d46-11ea-93ad-2403071772b4.png)

Not sure how/why it's breaking the regex generation - I tried escaping all the regex special characters and it still broke.

Don't have time to look closer into it so think just bailing on the transform when the regex breaks makes sense? It just skips that step completely, and renders the entire post content including the plaintext tags, as per the screenshot.