### PR TITLE
Fix job tag extraction

### DIFF
--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -31,13 +31,10 @@ export const extractTags = (message) => {
 
   let content = message;
   // remove tags from content
-  try {
-    content = content.replace(
-      new RegExp(matches.map((tag) => `\\${tag}`).join('|'), 'gi'),
-      '',
-    );
-  } catch(e) {
-  }
+  content = content.replace(
+    new RegExp(matches.map((tag) => `\\${tag}`).join('|'), 'gi'),
+    '',
+  );
   // remove leading whitespace and newlines
   content = content.replace(/^\s+\n+/gi, '');
 

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -25,7 +25,7 @@ export const addLinks = (content) => {
 export const extractTags = (message) => {
   const matches = message.match(/\[(.*?)\]/gi) || [];
 
-  const tags = matches.map((tag) => tag.replace('[', '').replace(']', ''));
+  const tags = matches.map((tag) => tag.slice(1, -1));
 
   let content = message;
   // remove tags from content

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -25,9 +25,7 @@ export const addLinks = (content) => {
 export const extractTags = (message) => {
   const matches = message.match(/\[(.*?)\]/gi) || [];
 
-  const tags = matches
-    .map((tag) => tag.replace('[', '').replace(']', ''))
-    .filter((x) => x.length < 15);
+  const tags = matches.map((tag) => tag.replace('[', '').replace(']', ''));
 
   let content = message;
   // remove tags from content

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -31,9 +31,9 @@ export const extractTags = (message) => {
 
   let content = message;
   // remove tags from content
-  content = content.replace(
-    new RegExp(matches.map((tag) => `\\${tag}`).join('|'), 'gi'),
-    '',
+  content = matches.reduce(
+    (content, match) => content.replace(match, ''),
+    content,
   );
   // remove leading whitespace and newlines
   content = content.replace(/^\s+\n+/gi, '');


### PR DESCRIPTION
Followup to #112

Rather than catching parsing errors for problematic tags (which prevents the page from crashing but leaves broken tags in the post body), this fixes the logic by not treating arbitrary job tag input text as regular expressions. I also tweaked how tags are generated to display longer tags and fix potential bugs.

## Before
![image](https://user-images.githubusercontent.com/927220/70828606-b02b3b80-1db9-11ea-86cc-837d8b06eb53.png)

## After
![image](https://user-images.githubusercontent.com/927220/70828645-c5a06580-1db9-11ea-8494-a871e45edde7.png)