### PR TITLE
Remove overflow h1 home page

### DIFF
--- a/src/components/Layout/LayoutStyles.js
+++ b/src/components/Layout/LayoutStyles.js
@@ -19,6 +19,10 @@ const title = {
 const homeLayout = css`
   display: block;
 
+  h1 {
+    overflow: hidden;
+  }
+  
   p {
     font-size: calc(1.7rem + 1vw);
     font-weight: 500;

--- a/src/components/Layout/MainStyles.js
+++ b/src/components/Layout/MainStyles.js
@@ -71,6 +71,7 @@ html body {
     font-family: 'Space Mono', monospace;
     font-size: 7.6rem;
     letter-spacing: -0.4rem;
+    overflow: hidden;
   }
 
   h2 {

--- a/src/components/Layout/MainStyles.js
+++ b/src/components/Layout/MainStyles.js
@@ -71,7 +71,6 @@ html body {
     font-family: 'Space Mono', monospace;
     font-size: 7.6rem;
     letter-spacing: -0.4rem;
-    overflow: hidden;
   }
 
   h2 {


### PR DESCRIPTION
Hey, I noticed that the font height of `<h1>` on the homepage resulted into part of the icons not being clickable. In the screenshot you can see that the blue area (selected text) overlaps part of the beneath text and icons, resulting in these parts not being clickable.

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/17083334/78437698-46d87c80-7677-11ea-85ca-6c837646cbde.png">

This PR adds an `overflow: hidden` to only the `h1` of the home page, resulting in no overlap, which is a minor UX improvement in my eyes:
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/17083334/78438241-6e2f4980-7677-11ea-88ac-dff9cc84d3e8.png">

Off course, if the name were to ever change to include a letter with a tail or descender this might not be such a good idea, an alternative implementation then could be something with `z-index`. But I don't expect a name change to happen soon 😉 