### PR TITLE
Add upcoming transcripts for summer

### DIFF
--- a/src/pages/schedule.js
+++ b/src/pages/schedule.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import { graphql } from 'gatsby';
+import styled from 'styled-components';
 
 import { Layout, Link } from '@components';
 import { groupBy, partition } from '@utils/array';
+
+const EventsDivider = styled.hr`
+  margin: 6rem 0;
+`;
 
 export default function Schedule({ data }) {
   const currentDate = new Date();
@@ -34,17 +39,19 @@ export default function Schedule({ data }) {
           <>
             <hr />
             <h2>Upcoming Q&A's & Meetups</h2>
-            {Object.entries(upcomingEvents).map(([dateGroup, events]) => (
-              <React.Fragment key={dateGroup}>
-                <h2>{dateGroup}</h2>
-                {events.map((event) => (
-                  <Event key={event.name} {...event} isUpcoming />
-                ))}
-              </React.Fragment>
-            ))}
+            {Object.entries(upcomingEvents)
+              .reverse()
+              .map(([dateGroup, events]) => (
+                <React.Fragment key={dateGroup}>
+                  <h2>{dateGroup}</h2>
+                  {events.map((event) => (
+                    <Event key={event.name} {...event} isUpcoming />
+                  ))}
+                </React.Fragment>
+              ))}
           </>
         )}
-        <hr />
+        <EventsDivider />
         <h2>Past Q&A's & Meetups</h2>
         {Object.entries(pastEvents).map(([dateGroup, events]) => (
           <React.Fragment key={dateGroup}>

--- a/src/transcripts/brandon-bayer.md
+++ b/src/transcripts/brandon-bayer.md
@@ -1,0 +1,8 @@
+---
+title: Brandon Bayer
+date: 2020-07-02
+time: 9AM - 10AM PT / 4PM GMT
+location: Q&A Channel Reactiflux
+description: 'Creator of [Blitz.js](https://blitzjs.com/), a monolithic React framework built on top of Next.js'
+people: '[@flybayer](https://twitter.com/flybayer)'
+---

--- a/src/transcripts/shawn-wang.md
+++ b/src/transcripts/shawn-wang.md
@@ -1,0 +1,8 @@
+---
+title: Shawn Wang
+date: 2020-06-11
+time: Noon EST / 4PM GMT
+location: Q&A Channel Reactiflux
+description: 'Senior Developer Advocate at AWS Mobile and author of [Cracking The Coding Career](https://twitter.com/Coding_Career)'
+people: '[@swyx](https://twitter.com/swyx)'
+---

--- a/src/transcripts/tanner-linsley-2.md
+++ b/src/transcripts/tanner-linsley-2.md
@@ -1,0 +1,8 @@
+---
+title: Tanner Linsley
+date: 2020-08-06
+time: 1PM - 2PM PT / 8PM GMT
+location: Q&A Channel Reactiflux
+description: 'Open Source developer known recently for react-query and react-virtual, and many other open source libraries.'
+people: '[@tannerlinsley](https://twitter.com/tannerlinsley)'
+---


### PR DESCRIPTION
Adding transcripts for June-August and increasing the space between Upcoming and Past events on the schedule. 

This also reverses the order of the upcoming events being displayed so that sooner events show first.