### PR TITLE
Replace Code of Conduct link with Guidelines link

### DIFF
--- a/src/components/Layout/Menu.js
+++ b/src/components/Layout/Menu.js
@@ -35,7 +35,7 @@ export function Menu() {
           <MobileNavIfMobile>
             <Link to="/contact/">Contact</Link>
             <Link to="/tips/">Tips</Link>
-            <Link to="/conduct/">Code of Conduct</Link>
+            <Link to="/guidelines/">Guidelines</Link>
             <Link to="/schedule/">Q&A Schedule</Link>
             <Link to="/transcripts/">Transcripts</Link>
             <Link to="/jobs/">Jobs</Link>


### PR DESCRIPTION
Fix #153

We have been preparing to deploy the Code of Conduct, but it's not actually at `/conduct` yet, so the link 404s. I only reverted the link update, and we can revert this again when we finish deploying it.