### PR TITLE
Fix transcripts article paths

### DIFF
--- a/src/pages/transcripts.js
+++ b/src/pages/transcripts.js
@@ -8,7 +8,7 @@ export default function Transcripts({ data }) {
     .filter((node) => node.childMarkdownRemark.html.trim().length)
     .map((node) => ({
       title: node.childMarkdownRemark.frontmatter.title,
-      path: `/${node.relativeDirectory}/${node.name}`,
+      path: `${node.name}`,
       html: node.childMarkdownRemark.html,
     }));
 
@@ -24,10 +24,7 @@ export default function Transcripts({ data }) {
               <ol>
                 {articles.map((article) => (
                   <li key={article.title}>
-                    <Link
-                      to={'/transcripts/' + article.path}
-                      title={article.title}
-                    >
+                    <Link to={'/transcripts/' + article.path}>
                       {article.title}
                     </Link>
                   </li>
@@ -53,7 +50,6 @@ export const pageQuery = graphql`
     ) {
       nodes {
         name
-        relativeDirectory
         childMarkdownRemark {
           html
           frontmatter {

--- a/src/pages/transcripts.js
+++ b/src/pages/transcripts.js
@@ -8,7 +8,7 @@ export default function Transcripts({ data }) {
     .filter((node) => node.childMarkdownRemark.html.trim().length)
     .map((node) => ({
       title: node.childMarkdownRemark.frontmatter.title,
-      path: `${node.name}`,
+      path: node.name,
       html: node.childMarkdownRemark.html,
     }));
 

--- a/src/templates/Transcript.js
+++ b/src/templates/Transcript.js
@@ -9,7 +9,7 @@ export default function Transcript({ data }) {
     .filter((node) => node.childMarkdownRemark.html.trim().length)
     .map((node) => ({
       title: node.childMarkdownRemark.frontmatter.title,
-      path: `/${node.relativeDirectory}/${node.name}`,
+      path: `${node.name}`,
       html: node.childMarkdownRemark.html,
     }));
 
@@ -64,7 +64,6 @@ export const pageQuery = graphql`
     ) {
       nodes {
         name
-        relativeDirectory
         childMarkdownRemark {
           html
           frontmatter {

--- a/src/templates/Transcript.js
+++ b/src/templates/Transcript.js
@@ -9,7 +9,7 @@ export default function Transcript({ data }) {
     .filter((node) => node.childMarkdownRemark.html.trim().length)
     .map((node) => ({
       title: node.childMarkdownRemark.frontmatter.title,
-      path: `${node.name}`,
+      path: node.name,
       html: node.childMarkdownRemark.html,
     }));
 


### PR DESCRIPTION
Upon perusing the site, I discovered that the articles in the
`transcripts` section failed to load. In the address bar, I noticed that
the URL was something along the lines of `/transcripts///david-mccabe`.
Upon further investigation, I realized that the `relativeDirectory`
property of the node was empty, thus resulting in this broken URL being
set as the path for the `transcript` article links.

This changes removes the `relativeDirectory` from the path, fixing the
links in the process.