### PR TITLE
Add Discord ID link to job author's name (#114)

### DIFF
--- a/src/components/Offer.js
+++ b/src/components/Offer.js
@@ -46,8 +46,9 @@ const GetInTouch = styled.p`
   }
 `;
 
-const getLink = (id) =>
+const getJobLink = (id) =>
   `https://discordapp.com/channels/102860784329052160/103882387330457600/${id}`;
+const getAuthorLink = (id) => `https://discordapp.com/users/${id}`;
 
 export const Offer = ({
   author,
@@ -73,8 +74,12 @@ export const Offer = ({
       ) : null}
       <div>
         <p>
-          Posted by <strong>{author.name}</strong> on{' '}
-          <Link to={getLink(id)}>{moment(date).format('MMMM Do YYYY')}</Link>
+          Posted by{' '}
+          <Link to={getAuthorLink(author.id)}>
+            <strong>{author.name}</strong>
+          </Link>{' '}
+          on{' '}
+          <Link to={getJobLink(id)}>{moment(date).format('MMMM Do YYYY')}</Link>
         </p>
         {onClickGetInTouch ? (
           <GetInTouch>

--- a/src/pages/jobs.js
+++ b/src/pages/jobs.js
@@ -189,11 +189,14 @@ const Jobs = () => {
           <Modal close={() => setModal(false)} isOpen={showModal}>
             <p>
               If the job post does not contain a dedicated email, link, or phone
-              number, you can click the offer date to open the original message
-              in our{' '}
-              <Link to="https://discord.gg/reactiflux">Discord server</Link> (in
-              the <strong>#jobs</strong> channel). You can then contact the
-              person by sending them a direct message.
+              number, you can click either the offer date to open the original
+              message in our{' '}
+              <Link to="https://discordapp.com/channels/102860784329052160">
+                Discord server
+              </Link>{' '}
+              (in the <strong>#job-board</strong> channel), or the name of the
+              user that posted the job. You can then contact the person by
+              sending them a direct message.
             </p>
             <p>
               If you don't already have one, you will need to create a (free!){' '}


### PR DESCRIPTION
* Add link containing author's Discord ID
  to job post author's name

* Update text in 'How can I get in touch?' modal
  to reflect the change