### PR TITLE
Update Discord links with direct invites to new channels

### DIFF
--- a/src/blog/2019-census/index.md
+++ b/src/blog/2019-census/index.md
@@ -26,7 +26,7 @@ All questions were optional, with the intent that if a question made a responden
 - Have you felt marginalized or harassed while in the Reactiflux Community?
 - Is there anything you'd like to suggest or tell the Reactiflux staff anonymously? (free answer)
 
-We carefully crafted these questions with the aim of being inclusive, and attempted to follow similar patterns set by other demographic-type surveys. If there's a question here that feels inappropriately phrased, or that you think could be improved, we would love to hear from you however you feel comfortable. You can give us feedback in [the #reactiflux-admin channel](https://discord.gg/reactiflux), DM one of the admins or mods in Discord, or DM [@reactiflux](https://twitter.com/reactiflux) on Twitter, or via our [anonymous contact form](/contact).
+We carefully crafted these questions with the aim of being inclusive, and attempted to follow similar patterns set by other demographic-type surveys. If there's a question here that feels inappropriately phrased, or that you think could be improved, we would love to hear from you however you feel comfortable. You can give us feedback in [the #reactiflux-moderation channel](https://discord.gg/BkSU7Ju), DM one of the admins or mods in Discord, or DM [@reactiflux](https://twitter.com/reactiflux) on Twitter, or via our [anonymous contact form](/contact).
 
 ## The results
 
@@ -90,4 +90,4 @@ We're disappointed, but not surprised, to see how male-skewed the population is.
 
 Government data from 2014 ([census.gov, page 10. PDF](https://www.census.gov/content/dam/Census/library/publications/2016/acs/acs-35.pdf)), however, shows web developers as 65% male, 35% female. This is a significant gap—there are substantially more women in our industry than participate in its communities. The conclusion we at Reactiflux draw from this is, **there is a persistent force that excludes women these communities.**
 
-Reactiflux finds itself in a unique position: we might be the largest realtime chat community for developers, and as such may be able to have a large impact on the broader industry through the norms we set. We're going to take some cues from other large chat communities (Rust, Python, and others), and would love to see any examples of welcoming communities you know of. Drop us a link to them in [#suggestions](https://discord.gg/reactiflux), and together we can make the internet a little bit better.
+Reactiflux finds itself in a unique position: we might be the largest realtime chat community for developers, and as such may be able to have a large impact on the broader industry through the norms we set. We're going to take some cues from other large chat communities (Rust, Python, and others), and would love to see any examples of welcoming communities you know of. Drop us a link to them in [#reactiflux-suggestions](https://discord.gg/XyRQxtM), and together we can make the internet a little bit better.

--- a/src/md-pages/conduct.md
+++ b/src/md-pages/conduct.md
@@ -27,7 +27,7 @@ This is not a legal document, members should follow the spirit of these guidelin
 These are the policies for upholding our community’s standards of conduct. If you feel that there is a situation that needs moderation, please contact the Reactiflux staff:
 
 - In-channel: 👎 react a message or ping @moderator
-- Public: [#reactiflux-admin](https://discord.gg/YKcXEDa)
+- Public: [#reactiflux-moderation](https://discord.gg/BkSU7Ju)
 - Private: private message any staff member
 - Anonymous: [anonymous contact form](/contact/)
 

--- a/src/md-pages/promotion.md
+++ b/src/md-pages/promotion.md
@@ -41,7 +41,7 @@ And "no" to:
 - Are you directly asking people to subscribe for updates?
 - Do people need to pay to benefit from what you're sharing?
 
-We grant more leeway to members who have been active participants in the community, as well. If you're unsure, please post in #reactiflux-admin or direct message any of the admins with your intended message, and we can help clarify.
+We grant more leeway to members who have been active participants in the community, as well. If you're unsure, please post in [#reactiflux-moderation](https://discord.gg/BkSU7Ju) or direct message any of the admins with your intended message, and we can help clarify.
 
 We want the majority of what's shared to be created by genuine members of Reactiflux. That could be asking questions, sharing knowledge, or simply following along with the chat (drop a note in #introductions!).
 

--- a/src/md-pages/tips.md
+++ b/src/md-pages/tips.md
@@ -15,7 +15,7 @@ You may get help within 5 minutes if somebody who knows the answer is looking fo
 
 ## Moderators need your help
 
-If you see something you feel is out-of-line, please use our `@moderator` ping to alert us. You can send it in **#reactiflux-admin** if you don't feel comfortable doing it inline, or can submit anonymously from our [report page](/contact). There's a buried way to [copy a direct link to a specific message](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-), which is very helpful when reporting.
+If you see something you feel is out-of-line, please use our `@moderator` ping to alert us. You can send it in **[#reactiflux-moderation](https://discord.gg/BkSU7Ju)** if you don't feel comfortable doing it inline, or can submit anonymously from our [report page](/contact). There's a buried way to [copy a direct link to a specific message](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-), which is very helpful when reporting.
 
 ## Ask your question
 
@@ -49,7 +49,7 @@ The other people in Reactiflux deserve your respect, so be polite. Not "retail e
 
 ## Be a model channel citizen
 
-Be the change you want to see in the world! If a conversation is getting heated, try to defuse it. If a hard question is unanswered, dig in and work through it with them. If a channel is full of unanswered questions, mention in **#reactiflux-admin** that you'd like to take ownership of it.
+Be the change you want to see in the world! If a conversation is getting heated, try to defuse it. If a hard question is unanswered, dig in and work through it with them. If a channel is full of unanswered questions, mention in **[#reactiflux-moderation](https://discord.gg/BkSU7Ju)** that you'd like to take ownership of it.
 
 ## Do your research
 

--- a/src/md-pages/tips.md
+++ b/src/md-pages/tips.md
@@ -15,7 +15,7 @@ You may get help within 5 minutes if somebody who knows the answer is looking fo
 
 ## Moderators need your help
 
-If you see something you feel is out-of-line, please use our `@moderator` ping to alert us. You can send it in **[#reactiflux-moderation](https://discord.gg/BkSU7Ju)** if you don't feel comfortable doing it inline, or can submit anonymously from our [report page](/contact). There's a buried way to [copy a direct link to a specific message](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-), which is very helpful when reporting.
+If you see something you feel is out-of-line, please use our `@moderator` ping to alert us. You can send it in [#reactiflux-moderation](https://discord.gg/BkSU7Ju) if you don't feel comfortable doing it inline, or can submit anonymously from our [report page](/contact). There's a buried way to [copy a direct link to a specific message](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-), which is very helpful when reporting.
 
 ## Ask your question
 
@@ -27,7 +27,7 @@ The answer is probably "yes," but nobody can help you until you state what your 
 
 > "Is it okay if I ask about [X tool or library] here?"
 
-Instead of asking, scan through the list of channels for any that seem like obvious fits for your question. If you don't see any, don't hesitate to post it in **#general** or **#need-help**. If there's a better place for it, one of the moderators or other helpful users will suggest it.
+Instead of asking, scan through the list of channels for any that seem like obvious fits for your question. If you don't see any, don't hesitate to post it in [#help-react](https://discord.gg/Wd9efFvBrk). If there's a better place for it, one of the moderators or other helpful users will suggest it.
 
 ## Ping people only when needed
 
@@ -49,7 +49,7 @@ The other people in Reactiflux deserve your respect, so be polite. Not "retail e
 
 ## Be a model channel citizen
 
-Be the change you want to see in the world! If a conversation is getting heated, try to defuse it. If a hard question is unanswered, dig in and work through it with them. If a channel is full of unanswered questions, mention in **[#reactiflux-moderation](https://discord.gg/BkSU7Ju)** that you'd like to take ownership of it.
+Be the change you want to see in the world! If a conversation is getting heated, try to defuse it. If a hard question is unanswered, dig in and work through it with them. If a channel is full of unanswered questions, mention in [#reactiflux-moderation](https://discord.gg/BkSU7Ju) that you'd like to take ownership of it.
 
 ## Do your research
 

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -46,7 +46,8 @@ const Index = () => {
         <ul>
           <li>
             The public{' '}
-            <a href="https://discord.gg/YKcXEDa">#reactiflux-admin</a> channel
+            <a href="https://discord.gg/BkSU7Ju">#reactiflux-moderation</a>{' '}
+            channel
           </li>
           <li>direct message to any staff member in Discord</li>
           <li>

--- a/src/pages/jobs.js
+++ b/src/pages/jobs.js
@@ -191,12 +191,11 @@ const Jobs = () => {
               If the job post does not contain a dedicated email, link, or phone
               number, you can click either the offer date to open the original
               message in our{' '}
-              <Link to="https://discord.com/channels/102860784329052160">
-                Discord server
-              </Link>{' '}
-              (in the <strong>#job-board</strong> channel), or the name of the
-              user that posted the job. You can then contact the person by
-              sending them a direct message.
+              <Link to="https://discord.gg/R942bNb">
+                <strong>#job-board</strong> channel
+              </Link>
+              , or the name of the user that posted the job. You can then
+              contact the person by sending them a direct message.
             </p>
             <p>
               If you don't already have one, you will need to create a (free!){' '}

--- a/src/pages/schedule.js
+++ b/src/pages/schedule.js
@@ -38,8 +38,8 @@ export default function Schedule({ data }) {
           someone specific in the community, let us know by contacting us via{' '}
           <Link to="https://twitter.com/reactiflux">Twitter</Link> or ping an
           admin or moderator in the{' '}
-          <Link to="https://discord.gg/BkSU7Ju">#reactiflux-admin</Link> channel
-          on discord.
+          <Link to="https://discord.gg/BkSU7Ju">#reactiflux-moderation</Link>{' '}
+          channel on discord.
         </p>
         {Object.keys(upcomingEvents).length > 0 && (
           <>


### PR DESCRIPTION
This solves two problems:
- Generic invite links like https://discord.gg/reactiflux being used when a specific channel invite is more useful
- Links that still use old channel names before they were renamed