### PR TITLE
correct external link for react roadmap | fix #197

### DIFF
--- a/src/md-pages/learning.md
+++ b/src/md-pages/learning.md
@@ -25,7 +25,7 @@ A selected list of tutorials, articles, and resources on Javascript, React, Redu
 - [Timeline for Learning React](https://daveceddia.com/timeline-for-learning-react/)  
   [How to Learn React](https://daveceddia.com/how-to-learn-react/)  
   Another high-level suggested timeline for how to approach learning React and related technologies.
-- [React Roadmap](https://github.com/ericdouglas/react-roadmap)  
+- [React Roadmap](https://roadmap.sh/react)  
   A curated list of free resources to master React Development, in suggested learning order
 - [Tips to learn React + Redux](https://www.robinwieruch.de/tips-to-learn-react-redux/)  
   An extensive and excellent list of suggestions to follow when learning and using React and Redux. Tips include when to use different component patterns, when to bring in a state management library, Redux state structuring, unit testing, and much more.


### PR DESCRIPTION
I have corrected the external link in the learning page for react roadmap.

It was broken earlier. 

As mentioned in the following issue : https://github.com/reactiflux/reactiflux.com/issues/197

Thanks