### PR TITLE
Corrected tab title on Q&A schedule page - Fixes #214

### DIFF
--- a/src/pages/schedule.tsx
+++ b/src/pages/schedule.tsx
@@ -31,7 +31,7 @@ export default function Schedule({
 }: Awaited<ReturnType<typeof getStaticProps>>["props"]) {
   return (
     <Layout
-      title="Q&amp;A Schedules"
+      title="Q&amp;A Schedule"
       as={undefined}
       description="Upcoming Q&A events in Reactiflux"
     >

--- a/src/pages/schedule.tsx
+++ b/src/pages/schedule.tsx
@@ -31,7 +31,7 @@ export default function Schedule({
 }: Awaited<ReturnType<typeof getStaticProps>>["props"]) {
   return (
     <Layout
-      title="Transcripts"
+      title="Q&amp;A Schedules"
       as={undefined}
       description="Upcoming Q&A events in Reactiflux"
     >


### PR DESCRIPTION
Corrected the tab title for Q&A Schedule pages from "Transcripts" to "Q&A Schedules".