### PR TITLE
Re-order and expand /promotion content 

### DIFF
--- a/src/components/Layout/LayoutStyles.js
+++ b/src/components/Layout/LayoutStyles.js
@@ -46,7 +46,6 @@ const homeLayout = css`
 
 const standardLayout = css`
   > * {
-    position: relative;
     z-index: 2;
   }
 
@@ -232,6 +231,7 @@ export function SidebarToggleButton(props) {
 }
 
 export const Wrapper = styled.div`
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   min-height: ${(props) =>

--- a/src/components/Layout/LayoutStyles.js
+++ b/src/components/Layout/LayoutStyles.js
@@ -54,6 +54,26 @@ const standardLayout = css`
     z-index: 1;
   }
 
+  details {
+    margin-bottom: 1rem;
+
+    & summary {
+      cursor: pointer;
+    }
+
+    &:last-of-type {
+      margin-bottom: 2rem;
+    }
+  }
+
+  blockquote {
+    font-size: 0.75em;
+    max-width: 40em;
+    margin-left: 1rem;
+    padding-left: 0.75rem;
+    border-left: 0.2rem solid #0003;
+  }
+
   @media (max-width: 819px) {
     display: grid;
     grid-template-rows: fit-content fit-content auto;

--- a/src/components/Layout/LayoutStyles.js
+++ b/src/components/Layout/LayoutStyles.js
@@ -56,6 +56,7 @@ const standardLayout = css`
 
   @media (max-width: 819px) {
     display: grid;
+    grid-template-rows: fit-content fit-content auto;
     grid-template-columns: 60% 100%;
     transform: translateX(
       ${(props) => (props.isOpen ? "0" : "calc(10px - 60%)")}
@@ -94,11 +95,12 @@ const standardLayout = css`
 
   @media (min-width: 820px) {
     display: grid;
+    grid-template-rows: fit-content fit-content auto;
     grid-template-columns: 1fr 2fr;
 
     > * {
       grid-column: 2;
-      grid-row: 2;
+      grid-row: 2 / span 2;
       min-width: calc(200% / 3);
     }
 

--- a/src/md-pages/promotion.md
+++ b/src/md-pages/promotion.md
@@ -1,6 +1,7 @@
 ---
 title: Self Promotion
 description: Promotional guidelines within the Reactiflux community.
+sidebar: true
 ---
 
 Reactiflux's members do lots of cool stuff, and we'd love for you to share what you've done! However Reactiflux is fundamentally a peer group, not an advertising channel or a free audience. Members who join only to promote something have what they share more aggressively moderated than members who participate in the community in other ways.
@@ -9,41 +10,9 @@ We have several channels where self-promotion is expected, and some other releva
 
 Interested in promoting something and aren’t sure? Reach out to the admins [by email](mailto:hello@reactiflux.com) or [on our contact page](/contact) to discuss.
 
-## [#i-wrote-this](https://discord.gg/xtmDRsShgm)
+# Self promotion vs advertising
 
-Here is best to share your own writing. Unless the content you’re posting is better suited to another channel, share it here. This is mainly intended to be a showcase for personal writing, but livestreams may also be shared here. Streams may only be shared once every 2 weeks.
-
-## [#i-built-this](https://discord.gg/GaCSDfm)
-
-New side projects, libraries, or other works you want to show off. This is predominantly meant as a showcase for individuals.
-
-## [#tech-reads-and-news](https://discord.gg/TEYnXKw)
-
-If you want to share an announcement of something new in the Javascript ecosystem, then this is the most appropriate channel. Reactiflux is not a free audience for advertisements, however — see our ["self promotion vs advertising" section of the page](#self-promotion-vs-advertising). This is also a channel for sharing and discussing interesting articles, blog posts, and books about JS, software development, the tech industry, and other relevant longform writings.
-
-## [#events](https://discord.gg/RYVBdtY)
-
-Announcing an upcoming conference or discussing an ongoing conference are both encouraged here. In general, we'd prefer conferences limit their announcements to 1 per major milestone. When it's announced, near registration deadlines, and when it's about to happen would be appropriate.
-
-## [#job-board](https://discord.gg/R942bNb)
-
-Our job board is our most strictly moderated channel. Posts should follow the rules and recommendataions in the channel description so they can be properly displayed and searched on our [jobs page](/jobs/). Please post at most once a week. There's some wiggle room when posting multiple positions, but please don't flood the channel.
-
-Posts must start with `[FORHIRE]` or `[HIRING]`. Lead with the location of the position and include LOCAL, REMOTE, INTERN, VISA, etc. and keep the message reasonably formatted & a reasonable length. Provide a means for applicants to contact you.
-
-Jobs are full-time salaried positions, or part- or full-time contract roles. We don't allow small gigs "pay for help" schemes, equity-only compensation, [spec work](https://www.nospec.com/), or other types of uncompensated labor. We do not have a channel for finding project collaborators.
-
-### Surveys
-
-Reactiflux only allows surveys from private organizations if they're shared by an active member of the community. Surveys may be posted if the results will be public or used for academic purposes, and should only be shared once. Fair warning: most surveys get relatively low uptake, they just aren't of interest to many in the community.
-
-### Outside communities
-
-Reactiflux generally does not allow external communities to be promoted. If another server would better serve someone asking a question (for example, asking a detailed python question in #general-tech), then members are welcome to share server invites. Announcements or promotions of communities must be of obvious interest to the majority of the Reactiflux community.
-
-### Self promotion vs advertising
-
-The line here can be thin. Reactiflux is a community, not a free marketing audience. If you have a body of content you'd like to promote, our recommended way of doing so is to be an active and positive member of the server. If someone has a question that you've created an external answer to, we'd love if you share it! Otherwise, we ask that you limit what you plug without prompting.
+The line between self promotion and advertising can be thin. Reactiflux is a community, not a free marketing audience. If you have a body of content you'd like to promote, our recommended way of doing so is to be an active and positive member of the server. If someone has a question that you've created an external answer to, we'd love if you share it! Otherwise, we ask that you limit what you plug without prompting.
 
 To help determine if what you want to share is an advertisement, here are some questions to help you decide.
 
@@ -64,10 +33,76 @@ We grant more leeway to members who have been active participants in the communi
 
 We want the majority of what's shared to be created by genuine members of Reactiflux. That could be asking questions, sharing knowledge, or simply following along with the chat (drop a note in #introductions!).
 
-### Events, vlogs, and periodic content
+# Promotion channels
 
-If you're hosting a conference, livestreamed event, Q&A session or similar, you're welcome to share. We have a #conferences channel, but many events are probably best to share in #news-and-links. If you're sharing episodic content, please refrain from promoting each new episode—we'd prefer that you share the show/channel/etc itself. For long-running shows we ask that you only promote it sporadically.
+## [#q-and-a](https://discord.gg/MbKwYuq)
 
-### Paid help and tutoring
+Reactiflux sometimes hosts conversations with prominent members of the community, and those working on interesting projects in the web development industry. If you're interested in participating, contact the moderators at [hello@reactiflux.com](mailto:hello@reactiflux.com).
+
+## [#job-board](https://discord.gg/R942bNb)
+
+Our job board is our most strictly moderated channel. Posts should follow the rules and recommendataions in the channel description so they can be properly displayed and searched on our [jobs page](/jobs/). If you're acting as a third-party recruiter, please [contact the moderators before posting](/contact).
+
+Posts must start with `[FORHIRE]` or `[HIRING]`. Lead with the location of the position and include `LOCAL`, `REMOTE`, `INTERN`, `VISA`, and keep the message reasonably formatted & a reasonable length — 1-2 paragraphs, please. Provide a means for applicants to contact you. e.g.:
+
+<details open>
+<summary>Global remote position</summary>
+<blockquote>
+<p>[HIRING]</p>
+
+<p>Senior React Engineer - [REMOTE]: $min - $max</p>
+
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+
+<p>More details & apply: https://example.com/apply</p>
+</blockquote>
+</details>
+
+<details>
+<summary>Local position with visa support</summary>
+<blockquote>
+<p>[HIRING]</p>
+
+<p>Senior React Engineer - NYC [LOCAL][visa]: $min - $max</p>
+
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+
+<p>More details & apply: https://example.com/apply</p>
+</blockquote>
+</details>
+
+Jobs are full-time salaried positions, or part- or full-time contract roles. We don't allow small gigs "pay for help" schemes, equity-only compensation, [spec work](https://www.nospec.com/), or other types of uncompensated labor. We do not have a channel for finding project collaborators.
+
+## [#events](https://discord.gg/RYVBdtY)
+
+Announcing an upcoming conference or discussing an ongoing conference are both encouraged here. In general, we'd prefer conferences limit their announcements to 1 per major milestone. When it's announced, near registration deadlines, and when it's about to happen would be appropriate.
+
+## [#i-wrote-this](https://discord.gg/xtmDRsShgm)
+
+Share your own writing here. This is mainly intended to be a showcase for personal writing and content produced by individuals, livestreams and other educational content may also be shared here. Episodic content may only be shared once every 2 weeks.
+
+## [#i-built-this](https://discord.gg/GaCSDfm)
+
+New side projects, libraries, or other works you want to show off. This is predominantly meant as a showcase for individuals, but may be used for launch announcements of indie works.
+
+# Specific types of promotion
+
+## Paid content
+
+Books, courses, and other bodies of work behind a pay wall should not be shared, except in response to another member. We encourage recommending materials that will help members advance, but strongly prefer it resemble networking rather than advertising.
+
+## Surveys
+
+Reactiflux only allows surveys from private organizations if they're shared by an active member of the community. Surveys may be posted if the results will be public or used for academic purposes, and should only be shared once. Fair warning: most surveys get relatively low uptake, they just aren't of interest to many in the community.
+
+## Outside communities
+
+Reactiflux generally does not allow external communities to be promoted. If another server would better serve someone asking a question (for example, asking a detailed python question in #general-tech), then members are welcome to share server invites. Announcements or promotions of communities must be of obvious interest to the majority of the Reactiflux community.
+
+## Events, vlogs, and periodic content
+
+If you're hosting a conference, livestreamed event, Q&A session or similar, you're welcome to share in #events. If you're sharing episodic content like a video series, livestream, or podcast, please refrain from promoting each new episode — we'd prefer that you share the show/channel/etc itself. For long-running shows we ask that you only promote it every 2 weeks at most.
+
+## Paid help and tutoring
 
 Reactiflux is a community of developers helping each other out, but sometimes the amount of help someone is seeking may become a significant time investment for the person helping them. In circumstances like this, Reactiflux supports our members reaching out to discuss private tutoring. This is only something we allow for members who are active in the main purpose of the server; members with low or infrequent activity are not allowed to make offers like this. Members should post publicly to ask permission to DM about tutoring, but discussion of the specific arrangements (frequency, compensation, etc) should be done in private. Reactiflux staff are not able to mediate disputes that arise from arrangements like this, and members who participate in this way are subjected to increased moderator scrutiny.

--- a/src/md-pages/promotion.md
+++ b/src/md-pages/promotion.md
@@ -29,9 +29,9 @@ And "no" to:
 - Are you directly asking people to subscribe for updates?
 - Do people need to pay to benefit from what you're sharing?
 
-We grant more leeway to members who have been active participants in the community, as well. If you're unsure, please post in [#reactiflux-moderation](https://discord.gg/BkSU7Ju) or direct message any of the admins with your intended message, and we can help clarify.
+We grant more leeway to members who have been active participants in the community, as well. If you're unsure, reach out to the admins [by email](mailto:hello@reactiflux.com) or [on our contact page](/contact) to discuss.
 
-We want the majority of what's shared to be created by genuine members of Reactiflux. That could be asking questions, sharing knowledge, or simply following along with the chat (drop a note in #introductions!).
+We want the majority of what's shared to be created by genuine members of Reactiflux. Active members ask questions, share knowledge, or simply follow along with the chat (make sure to drop a note in #introductions!).
 
 # Promotion channels
 

--- a/src/pages/[md-page].tsx
+++ b/src/pages/[md-page].tsx
@@ -39,7 +39,7 @@ export default function MarkdownPage({
                     .filter((heading) => heading.depth < 3)
                     .map(({ value, depth }) => (
                       <li key={value}>
-                        <p style={{ paddingLeft: `${depth}rem` }}>
+                        <p style={{ paddingLeft: `${depth - 1}rem` }}>
                           <Link
                             href={getAnchor(value)}
                             onClick={() => {

--- a/src/pages/[md-page].tsx
+++ b/src/pages/[md-page].tsx
@@ -37,20 +37,22 @@ export default function MarkdownPage({
                 <ol>
                   {headings
                     .filter((heading) => heading.depth < 3)
-                    .map(({ value }) => (
+                    .map(({ value, depth }) => (
                       <li key={value}>
-                        <Link
-                          href={getAnchor(value)}
-                          onClick={() => {
-                            setSidebar(false);
-                            const heading = document.getElementById(
-                              getAnchor(value).replace("#", ""),
-                            );
-                            heading?.querySelector("a")?.focus();
-                          }}
-                        >
-                          {value}
-                        </Link>
+                        <p style={{ paddingLeft: `${depth}rem` }}>
+                          <Link
+                            href={getAnchor(value)}
+                            onClick={() => {
+                              setSidebar(false);
+                              const heading = document.getElementById(
+                                getAnchor(value).replace("#", ""),
+                              );
+                              heading?.querySelector("a")?.focus();
+                            }}
+                          >
+                            {value}
+                          </Link>
+                        </p>
                       </li>
                     ))}
                 </ol>


### PR DESCRIPTION
* Display a sidebar with all headings
* Remove #tech-reads-and-news since it's not really a promotion channel
* Add example job postings with nice formatting
* Move "Self promotion vs advertising" to the top
* Add #q-and-a channel description
* Small improvements to other sections to correct for drift between policies and these descriptions

Also fixes #181, and adds indentation based on heading depth in the sidebar.