### PR TITLE
Feature/#236: Fix Jobs page crashing

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -114,5 +114,5 @@ export const Modal = ({ children, close, isOpen }) => {
     </ReturnFocusOnUnMount>
   );
 
-  return createPortal(content, document.getElementById("modals"));
+  return createPortal(content, document.body);
 };


### PR DESCRIPTION
PR for #236

This pull request fixes the "How can I get in touch?" button on the Jobs page crashing the page. 

The error being thrown was caused by the modal displayed when clicking the button attempting to render in a React portal in which the containing element didn't exist.

### Changes

- Update the modal React portal container element to be the document body.

### Notes

-  The document body is the default element that I use as a container to render fullscreen modals in a React portal as it enables the modal to be rendered higher in the tree than the rest of the application.
- I didn't have time to look through the history to see where the regression was introduced but there's no evidence left of the previous React portal container element. As it's a fairly impactful bug that's live in production, I thought it'd be best to push a fix quickly. I also prefer the proposed implementation in this pull request.