### PR TITLE
feat: Dynamic user count

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "next build"
+  command = "yarn build"
   publish = ".next/"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "next build && next start"
+  command = "next build"
   publish = "out/"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "next build"
+  command = "next build && next start"
   publish = "out/"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "yarn start"
+  command = "next build && next start"
   publish = "out/"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "yarn build"
+  command = "yarn start"
   publish = "out/"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = "next build"
-  publish = "out/"
+  publish = ".next/"
 
 [[redirects]]
   from = "/guidelines"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,6 @@
 [[redirects]]
   from = "/guidelines"
   to = "/conduct"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "test": "next lint && prettier --check .",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -31,7 +31,7 @@ const P = styled.p`
       : ""}
 `;
 
-const Index = () => {
+const Index = ({ userCount }) => {
   return (
     <Layout title="Welcome" homepage>
       <h1>
@@ -39,7 +39,11 @@ const Index = () => {
         Reactiflux
       </h1>
       <p>
-        We’re a chat community of 170,000+ React&nbsp;JS&nbsp;
+        We’re a chat community of{" "}
+        {`${new Intl.NumberFormat("en-US").format(
+          Math.floor(userCount / 1000) * 1000,
+        )}+`}{" "}
+        React&nbsp;JS&nbsp;
         <Link href="https://github.com/facebook/react" title="React JS">
           <Image {...ReactLogo} alt="React JS" />
         </Link>
@@ -96,6 +100,31 @@ const Index = () => {
       </P>
     </Layout>
   );
+};
+
+export const getStaticProps = async () => {
+  const fallbackUserCount = 200000;
+
+  try {
+    const r = await fetch(
+      `https://discord.com/api/v9/invites/reactiflux?with_counts=true&with_expiration=true`,
+      { method: "get" },
+    );
+    const data = await r.json();
+
+    return {
+      props: {
+        userCount: data?.approximate_member_count || fallbackUserCount,
+      },
+    };
+  } catch {
+    return {
+      revalidate: 60,
+      props: {
+        userCount: fallbackUserCount,
+      },
+    };
+  }
 };
 
 export default Index;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -100,7 +100,7 @@ const Index = ({ userCount }) => {
 };
 
 export const getStaticProps = async () => {
-  const fallbackUserCount = 200000;
+  const fallbackUserCount = 200_000;
 
   try {
     const r = await fetch(

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -110,6 +110,7 @@ export const getStaticProps = async () => {
     const data = await r.json();
 
     return {
+      revalidate: 60,
       props: {
         userCount: data?.approximate_member_count || fallbackUserCount,
       },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -40,9 +40,7 @@ const Index = ({ userCount }) => {
       </h1>
       <p>
         We’re a chat community of{" "}
-        {`${new Intl.NumberFormat("en-US").format(
-          Math.floor(userCount / 1000) * 1000,
-        )}+`}{" "}
+        {new Intl.NumberFormat("en-US").format(userCount)}{" "}
         React&nbsp;JS&nbsp;
         <Link href="https://github.com/facebook/react" title="React JS">
           <Image {...ReactLogo} alt="React JS" />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -40,8 +40,7 @@ const Index = ({ userCount }) => {
       </h1>
       <p>
         We’re a chat community of{" "}
-        {new Intl.NumberFormat("en-US").format(userCount)}{" "}
-        React&nbsp;JS&nbsp;
+        {new Intl.NumberFormat("en-US").format(userCount)} React&nbsp;JS&nbsp;
         <Link href="https://github.com/facebook/react" title="React JS">
           <Image {...ReactLogo} alt="React JS" />
         </Link>


### PR DESCRIPTION
- Channged the Discord's user count on the homepage. We now fetch the `approximate_member_count` from the Discord API and replace the default value of 200000. The user count is now also formatted by Intl.Numberformat, and rounded down to thousands.

All of this happens on getStaticProps of the index.js page, with a revalidation time of 60 seconds