### PR TITLE
Feature: Fix flash of unstyled text

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -11,8 +11,6 @@ import { MarkdownStyles } from "./MarkdownStyles";
 import { Menu } from "./Menu";
 import { SEO } from "./SEO";
 
-import "minireset.css";
-
 export function Layout({
   as,
   children,

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -12,9 +12,6 @@ import { Menu } from "./Menu";
 import { SEO } from "./SEO";
 
 import "minireset.css";
-import "typeface-poppins";
-import "typeface-work-sans";
-import "typeface-space-mono";
 
 export function Layout({
   as,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,10 @@ import "@styles/globals.css";
 import type { AppProps } from "next/app";
 import Script from "next/script";
 
+import "typeface-poppins";
+import "typeface-work-sans";
+import "typeface-space-mono";
+
 const GA_TRACKING_ID = "G-HYLJ4BYC6Z";
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import "@styles/globals.css";
 import type { AppProps } from "next/app";
 import Script from "next/script";
 
+import "minireset.css";
 import "typeface-poppins";
 import "typeface-work-sans";
 import "typeface-space-mono";


### PR DESCRIPTION
PR for fixing the flash of unstyled text which is rather jarring and appears to cause a layout shift.

This pull request fixes the FOUT by relocating the font imports from the layout component into the `_app` file.

### Changes

- Relocate font imports from the `Layout` component into the `_app` file.
- Relocate the CSS reset import from the `Layout` component into the `_app` file.

### Notes

- I went for the simplest solution I could find here. Hopefully, we can use Next's font loaders when we upgrade to Next 13.
- I've also relocated the CSS reset for consistency.
- I don't use Next very often so if we have any Next experts then please feel free to advise whether or not this is the correct place to import such assets.