### PR TITLE
fix: replace deprecated withComponent with as prop

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -35,4 +35,4 @@ export const Button = styled.button`
   }
 `;
 
-export const ButtonLink = Button.withComponent(Link);
+export const ButtonLink = (props) => <Button as="a" {...props} />;


### PR DESCRIPTION
When I ran the app, I saw the following warning on console:

```
Warning: Received `true` for a non-boolean attribute `secondary`.

If you want to write it to the DOM, pass a string instead: secondary="true" or secondary={value.toString()}.
    at a
    at Link (webpack-internal:///./node_modules/next/dist/client/link.js:66:23)
    at Link (webpack-internal:///./src/components/Link.tsx:16:17)
    at I (/Users/itsuka/_dev/github/reactiflux.com/node_modules/styled-components/dist/styled-components.cjs.js:1:19220)
    at p
    at I (/Users/itsuka/_dev/github/reactiflux.com/node_modules/styled-components/dist/styled-components.cjs.js:1:19220)
    at main
    at I (/Users/itsuka/_dev/github/reactiflux.com/node_modules/styled-components/dist/styled-components.cjs.js:1:19220)
    at div
    at I (/Users/itsuka/_dev/github/reactiflux.com/node_modules/styled-components/dist/styled-components.cjs.js:1:19220)
    at exports.ThemeProvider (/Users/itsuka/_dev/github/reactiflux.com/node_modules/styled-components/dist/styled-components.cjs.js:1:24917)
    at Layout (webpack-internal:///./src/components/Layout/Layout.js:30:19)
    at Index (webpack-internal:///./src/pages/index.js:35:18)
    at MyApp (webpack-internal:///./src/pages/_app.tsx:27:18)
    at ae (/Users/itsuka/_dev/github/reactiflux.com/node_modules/styled-components/dist/styled-components.cjs.js:1:13296)
    at InnerApp
    at StyleRegistry (/Users/itsuka/_dev/github/reactiflux.com/node_modules/styled-jsx/dist/stylesheet-registry.js:231:34)
    at AppContainer (/Users/itsuka/_dev/github/reactiflux.com/node_modules/next/dist/server/render.js:339:29)
    at AppContainerWithIsomorphicFiberStructure (/Users/itsuka/_dev/github/reactiflux.com/node_modules/next/dist/server/render.js:369:57)
```

Here's the offending code:

```ts
export const ButtonLink = Button.withComponent(Link);
```

I'm not exactly sure the issue since I've never used `withComponent` before. But if I replaced this (soon-to-be deprecated) API with the polymorphic `as` prop, the warning goes away:

```ts
export const ButtonLink = (props) => <Button as="a" {...props} />; // after fix
```

I had tested the fix and observed no regression.