### PR TITLE
fix: nodejs links are not redirecting to the correct path

### DIFF
--- a/src/md-pages/learning.md
+++ b/src/md-pages/learning.md
@@ -74,8 +74,8 @@ Mark's post series that describes the key terms, concepts, technologies, syntax,
   - [A Complete Guide to Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
   - [A Complete Guide to Grid](https://css-tricks.com/snippets/css/complete-guide-grid/)
 - Node / NPM
-  - [How to install Node.js](https://nodejs.dev/learn/how-to-install-nodejs)
-  - [An introduction to the npm package manager](https://nodejs.dev/learn/an-introduction-to-the-npm-package-manager)
+  - [How to install Node.js](https://nodejs.dev/en/learn/how-to-install-nodejs)
+  - [An introduction to the npm package manager](https://nodejs.dev/en/learn/an-introduction-to-the-npm-package-manager)
 - Build Tools
   - [The Many Jobs of JS Build Tools](https://www.swyx.io/jobs-of-js-build-tools/)
 - Debugging
@@ -116,8 +116,8 @@ Mark's post series that describes the key terms, concepts, technologies, syntax,
   - [A Practical CSS Cheat Sheet](https://www.toptal.com/css/css-cheat-sheet)
   - [GRID: A simple visual cheatsheet for CSS Grid Layout](http://grid.malven.co/)
 - Node / NPM
-  - [Introduction to Node.js](https://nodejs.dev/learn)
-  - [The package.json guide](https://nodejs.dev/learn/the-package-json-guide)
+  - [Introduction to Node.js](https://nodejs.dev/en/learn)
+  - [The package.json guide](https://nodejs.dev/en/learn/the-package-json-guide)
 - Lodash
   - [Lodash documentation](https://lodash.com/docs/)
 - Build Tools

--- a/src/md-pages/learning.md
+++ b/src/md-pages/learning.md
@@ -117,7 +117,6 @@ Mark's post series that describes the key terms, concepts, technologies, syntax,
   - [GRID: A simple visual cheatsheet for CSS Grid Layout](http://grid.malven.co/)
 - Node / NPM
   - [Introduction to Node.js](https://nodejs.dev/en/learn)
-  - [The package.json guide](https://nodejs.dev/en/learn/the-package-json-guide)
 - Lodash
   - [Lodash documentation](https://lodash.com/docs/)
 - Build Tools


### PR DESCRIPTION
The following links in the [learning page](https://www.reactiflux.com/learning) were not working so I changed them to the correct ones.

1. [How to install Node.js](https://nodejs.dev/learn/how-to-install-nodejs)
2. [An introduction to the npm package manager](https://nodejs.dev/learn/an-introduction-to-the-npm-package-manager)
3. [Introduction to Node.js](https://nodejs.dev/learn)

also the bellow link is not found but I couldn't figure out where it should redirect to.

- [The package.json guide](https://nodejs.dev/learn/the-package-json-guide)