### PR TITLE
Add redirect to Spotify Creators landing page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,5 +6,11 @@
   from = "/guidelines"
   to = "/conduct"
 
+[[redirects]]
+  from = "/tmir"
+  to = "https://creators.spotify.com/pod/profile/reactiflux/"
+  status = 302
+  force = true
+
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/src/md-pages/tmir.md
+++ b/src/md-pages/tmir.md
@@ -3,6 +3,9 @@ title: This Month in React
 description: "How busy professionals stay on top of the React ecosystem. We give you a 1 hour recap of the latest news and nuance in the React sphere. New episodes the first week of every month, with live recordings on the last Wednesday of every month in the Reactiflux stage.
 
 Hosted by friends and veterans of the community, Mark Erikson, Carl Vitullo, and Mo Khazali. They've been driving forces in the Reactiflux Discord since 2015. Mark brings his many years maintaining Redux, Carl his experience at a half-dozen startups, and Mo his depth with React Native from Theodo UK."
+
+
+# This page has been redirected to Spotify Creators in netlify.toml
 ---
 
 How busy professionals stay on top of the React ecosystem. We give you a 1 hour recap of the latest news and nuance in the React sphere. New episodes the first week of every month, with live recordings on the last Wednesday of every month in the Reactiflux stage.


### PR DESCRIPTION
I don't want this to be the permanent landing page, so this is a 302 redirect that will let me use a permalink while still taking advantage of the current landing page for the podcast.

I'd like to get the podcast off Spotify, because fuck spotify, but inertia is preventing me thus far. Maintaining control over a landing page keeps that door open effectively, while letting me e.g. print QR codes to hand out at conferences