### PR TITLE
Redirect /tmir to Transistor instead of Spotify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
 
 [[redirects]]
   from = "/tmir"
-  to = "https://creators.spotify.com/pod/profile/reactiflux/"
+  to = "https://tmir.transistor.fm/"
   status = 302
   force = true
 


### PR DESCRIPTION
We changed hosts earlier this year, Transistor is way better