### PR TITLE
docs(promotion): replace dead nospec.com link with AIGA position on spec work

### DIFF
--- a/src/md-pages/promotion.md
+++ b/src/md-pages/promotion.md
@@ -24,7 +24,7 @@ You should be able to answer "yes" to:
 And "no" to:
 
 - Are you announcing an announcement?
-- Are you soliciting [spec work](https://www.nospec.com/)?
+- Are you soliciting [spec work](https://www.aiga.org/resources/aiga-position-on-spec-work)?
 - Are you running a giveaway, airdrop, or other contest?
 - Are you directly asking people to subscribe for updates?
 


### PR DESCRIPTION
## Summary

The Promotion guidelines page (\`src/md-pages/promotion.md:27\`) referenced \`https://www.nospec.com/\` to explain 'spec work':

\`\`\`md
- Are you soliciting [spec work](https://www.nospec.com/)?
\`\`\`

That domain has expired, so readers hitting the link no longer get an explanation of spec work. Replaced with AIGA's canonical position statement on spec work, which the maintainers called out as the preferred alternative in the issue.

Closes #364

## Testing

Docs-only change. Verified https://www.aiga.org/resources/aiga-position-on-spec-work currently renders the AIGA position.